### PR TITLE
refactor: centralize timestamp formatting

### DIFF
--- a/components/CommentItem.tsx
+++ b/components/CommentItem.tsx
@@ -2,16 +2,14 @@
 import React from 'react';
 import { View, Text } from 'react-native';
 import { Comment } from '../types';
-import { format } from 'date-fns';
+import { formatTimestamp } from '../src/utils/formatTimestamp';
 
 interface Props {
   comment: Comment;
 }
 
 const CommentItem: React.FC<Props> = ({ comment }) => {
-  const date = comment.createdAt?.toDate
-    ? format(comment.createdAt.toDate(), 'yyyy-MM-dd HH:mm')
-    : '';
+  const date = formatTimestamp(comment.createdAt);
   return (
     <View className="p-2 border-b border-gray-100">
       <Text className="text-sm text-gray-500 mb-1">

--- a/docs/timestamp-format.md
+++ b/docs/timestamp-format.md
@@ -1,0 +1,5 @@
+# Timestamp Formatting
+
+The project uses a single utility, `formatTimestamp` (`src/utils/formatTimestamp.ts`), to convert Firestore `Timestamp` values or JavaScript `Date` objects into display strings.
+
+To change how timestamps are displayed across the application, update the implementation of `formatTimestamp`.

--- a/src/screens/PostDetailScreen.tsx
+++ b/src/screens/PostDetailScreen.tsx
@@ -7,7 +7,7 @@ import { Comment } from '../../types';
 import CommentItem from '../../components/CommentItem';
 import { db } from '../firebase/firebaseConfig';
 import { collection, addDoc, serverTimestamp, query, orderBy, onSnapshot } from 'firebase/firestore';
-import { format } from 'date-fns';
+import { formatTimestamp } from '../utils/formatTimestamp';
 
 type DetailProps = NativeStackScreenProps<RootStackParamList, 'PostDetail'>;
 
@@ -47,9 +47,7 @@ const PostDetailScreen: React.FC<DetailProps> = ({ route }) => {
       Alert.alert('오류', error.message);
     }
   };
-    const formattedDate = post.createdAt?.toDate
-    ? format(post.createdAt.toDate(), 'yyyy-MM-dd HH:mm')
-    : '';
+  const formattedDate = formatTimestamp(post.createdAt);
 
   return (
     <KeyboardAvoidingView

--- a/src/screens/PostListScreen.tsx
+++ b/src/screens/PostListScreen.tsx
@@ -4,7 +4,7 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../navigation/AppNavigator';
 import { Post } from '../../types';
 import { db } from '../firebase/firebaseConfig';
-import { format } from 'date-fns';
+import { formatTimestamp } from '../utils/formatTimestamp';
 import { collection, query, orderBy, onSnapshot } from 'firebase/firestore';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'PostList'>;
@@ -27,9 +27,7 @@ const PostListScreen: React.FC<Props> = ({ navigation }) => {
         data={posts}
         keyExtractor={item => item.id}
         renderItem={({ item }) => {
-          const date = item.createdAt?.toDate
-            ? format(item.createdAt.toDate(), 'yyyy-MM-dd HH:mm')
-            : '';
+          const date = formatTimestamp(item.createdAt);
           return (
             <Pressable
               className="p-4 border-b border-gray-200"

--- a/src/utils/formatTimestamp.ts
+++ b/src/utils/formatTimestamp.ts
@@ -1,0 +1,14 @@
+import { format } from 'date-fns';
+import type { Timestamp } from 'firebase/firestore';
+
+/**
+ * Format a Firebase Timestamp or Date to a human-readable string.
+ * Update this function to change the timestamp format across the app.
+ */
+export function formatTimestamp(
+  timestamp?: Timestamp | Date | null
+): string {
+  if (!timestamp) return '';
+  const date = timestamp instanceof Date ? timestamp : timestamp.toDate();
+  return format(date, 'yyyy-MM-dd HH:mm');
+}


### PR DESCRIPTION
## Summary
- add `formatTimestamp` utility for consistent date formatting
- refactor comment and post screens to use the new formatter
- document timestamp formatting utility

## Testing
- `npm run lint` *(fails: Unable to resolve path to module '@react-navigation/native-stack', '@react-navigation/native-stack')*
- `npm install @react-navigation/native-stack` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68943f158dec832597991f63d4c02104