### PR TITLE
chore: add semicolon to global css import

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,7 +2,7 @@ import 'react-native-gesture-handler';
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import AppNavigator from './src/navigation/AppNavigator';
-import './global.css'
+import './global.css';
 const App: React.FC = () => (
   <NavigationContainer>
     <AppNavigator />


### PR DESCRIPTION
## Summary
- add missing semicolon for global css import in App.tsx

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unable to resolve path to module '@react-navigation/native-stack')*

------
https://chatgpt.com/codex/tasks/task_e_68943f150fb4832592405d14f70ffbc7