### PR TITLE
feat: add timestamp formatter

### DIFF
--- a/components/CommentItem.tsx
+++ b/components/CommentItem.tsx
@@ -2,16 +2,14 @@
 import React from 'react';
 import { View, Text } from 'react-native';
 import { Comment } from '../types';
-import { format } from 'date-fns';
+import { formatTimestamp } from '../src/utils/formatTimestamp';
 
 interface Props {
   comment: Comment;
 }
 
 const CommentItem: React.FC<Props> = ({ comment }) => {
-  const date = comment.createdAt?.toDate
-    ? format(comment.createdAt.toDate(), 'yyyy-MM-dd HH:mm')
-    : '';
+  const date = formatTimestamp(comment.createdAt);
   return (
     <View className="p-2 border-b border-gray-100">
       <Text className="text-sm text-gray-500 mb-1">

--- a/src/screens/PostDetailScreen.tsx
+++ b/src/screens/PostDetailScreen.tsx
@@ -7,7 +7,7 @@ import { Comment } from '../../types';
 import CommentItem from '../../components/CommentItem';
 import { db } from '../firebase/firebaseConfig';
 import { collection, addDoc, serverTimestamp, query, orderBy, onSnapshot } from 'firebase/firestore';
-import { format } from 'date-fns';
+import { formatTimestamp } from '../utils/formatTimestamp';
 
 type DetailProps = NativeStackScreenProps<RootStackParamList, 'PostDetail'>;
 
@@ -47,9 +47,7 @@ const PostDetailScreen: React.FC<DetailProps> = ({ route }) => {
       Alert.alert('오류', error.message);
     }
   };
-    const formattedDate = post.createdAt?.toDate
-    ? format(post.createdAt.toDate(), 'yyyy-MM-dd HH:mm')
-    : '';
+    const formattedDate = formatTimestamp(post.createdAt);
 
   return (
     <KeyboardAvoidingView

--- a/src/screens/PostListScreen.tsx
+++ b/src/screens/PostListScreen.tsx
@@ -4,8 +4,8 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../navigation/AppNavigator';
 import { Post } from '../../types';
 import { db } from '../firebase/firebaseConfig';
-import { format } from 'date-fns';
 import { collection, query, orderBy, onSnapshot } from 'firebase/firestore';
+import { formatTimestamp } from '../utils/formatTimestamp';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'PostList'>;
 
@@ -23,13 +23,11 @@ const PostListScreen: React.FC<Props> = ({ navigation }) => {
 
   return (
     <View className="flex-1 p-4 bg-white">
-<FlatList
+      <FlatList
         data={posts}
         keyExtractor={item => item.id}
         renderItem={({ item }) => {
-          const date = item.createdAt?.toDate
-            ? format(item.createdAt.toDate(), 'yyyy-MM-dd HH:mm')
-            : '';
+          const date = formatTimestamp(item.createdAt);
           return (
             <Pressable
               className="p-4 border-b border-gray-200"
@@ -44,7 +42,10 @@ const PostListScreen: React.FC<Props> = ({ navigation }) => {
         }}
         className="mb-4"
       />
-      <Pressable className="bg-blue-500 rounded-md py-3" onPress={() => navigation.navigate('CreatePost')}>
+      <Pressable
+        className="bg-blue-500 rounded-md py-3"
+        onPress={() => navigation.navigate('CreatePost')}
+      >
         <Text className="text-center text-white font-semibold">글쓰기</Text>
       </Pressable>
     </View>

--- a/src/utils/formatTimestamp.ts
+++ b/src/utils/formatTimestamp.ts
@@ -1,0 +1,9 @@
+import { Timestamp } from 'firebase/firestore';
+import { format } from 'date-fns';
+
+export const formatTimestamp = (timestamp?: Timestamp | null): string => {
+  const date = timestamp?.toDate();
+  return date ? format(date, 'yyyy-MM-dd HH:mm') : '';
+};
+
+export default formatTimestamp;


### PR DESCRIPTION
## Summary
- add formatTimestamp util for consistent Timestamp formatting
- use formatTimestamp across post list, post detail and comments

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unable to resolve path to module)


------
https://chatgpt.com/codex/tasks/task_e_68943f12869c832598ad7558b6150317